### PR TITLE
Update links that were giving 403 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Welcome to the Apto iOS UI SDK. This SDK provides access to Apto's mobile platform, and is designed for you to control the UI/UX.
 
-For more information about the SDK and deployment, see the [iOS UI SDK docs](https://docs.aptopayments.com/docs/ui-sdk-ios)
+For more information about the SDK and deployment, see the [iOS UI SDK docs](https://docs.aptopayments.com/docs/sdks/iOS/ui_sdk_ios)
 
 
 ## Contributions & Development
 
 We look forward to receiving your feedback, including new feature requests, bug fixes and documentation improvements.
 
-If you would like to contribute to the SDK development, see [Contributions & Development](https://docs.aptopayments.com/docs/ui-sdk-ios#contributions--development).
+If you would like to contribute to the SDK development, see [Contributions & Development](https://docs.aptopayments.com/docs/sdks/iOS/ui_sdk_ios#contributions--development).


### PR DESCRIPTION
old links had dashes while new docs links have underscore